### PR TITLE
Update signal for latest django

### DIFF
--- a/openhumans/signals.py
+++ b/openhumans/signals.py
@@ -8,5 +8,4 @@ member_deauth: Sent when the 'deauth' webhook URL is called by Open Humans,
 import django.dispatch
 
 
-member_deauth = django.dispatch.Signal(providing_args=[
-    "open_humans_member", "erasure_requested"])
+member_deauth = django.dispatch.Signal()

--- a/openhumans/urls.py
+++ b/openhumans/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import re_path as url
 from . import views
 
 app_name = 'openhumans'

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     description='Django module for interacting with Open Humans',
     long_description=readme(),
 
-    version='0.1.8',
+    version='0.1.9',
 
     license='MIT',
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     description='Django module for interacting with Open Humans',
     long_description=readme(),
 
-    version='0.1.7',
+    version='0.1.8',
 
     license='MIT',
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def readme():
 # Add backport of futures unless Python version is 3.2 or later.
 install_requires = [
     'open-humans-api>=0.2.4',
-    'django>=2.1'
+    'django>=4.0'
 ]
 if sys.version_info < (3, 5):
     raise RuntimeError("This package requres Python 3.5+")

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     description='Django module for interacting with Open Humans',
     long_description=readme(),
 
-    version='0.1.6',
+    version='0.1.7',
 
     license='MIT',
 


### PR DESCRIPTION
Current django versions have removed the `providing_args` argument from the Signal class (see [Django release notes](https://docs.djangoproject.com/en/4.0/releases/3.1/#id2)). These arguments were never used and only used for documentation purposes. 

In our case the doc string already provides the documentation, so we can just remove it here.