### PR TITLE
Support explicit deauth

### DIFF
--- a/openhumans/models.py
+++ b/openhumans/models.py
@@ -255,3 +255,21 @@ class OpenHumansMember(models.Model):
             project_member_id=self.oh_id,
             access_token=self.get_access_token(),
             all_files=True)
+
+    def deauth(self):
+        """
+        Deauthorize the OpenHumans account.
+
+        This does not delete the account locally. If access is needed to the
+        OpenHumans functionality associated with the account after this call
+        the ``OpenHumansMember`` would need to be re-authorized.
+
+        See also: :ref:`OPENHUMANS_DELETE_ON_DEAUTH`
+        """
+        withdraw_url = urljoin(
+            OPENHUMANS_OH_BASE_URL,
+            '/api/direct-sharing/project/remove-members/')
+        withdraw_url = urljoin(
+            withdraw_url,
+            '?access_token={}'.format(self.get_access_token()))
+        requests.post(withdraw_url)

--- a/openhumans/receivers.py
+++ b/openhumans/receivers.py
@@ -61,10 +61,4 @@ def deauth_on_delete(**kwargs):
     """
     if OPENHUMANS_DEAUTH_ON_DELETE:
         instance = kwargs['instance']
-        withdraw_url = urljoin(
-            OPENHUMANS_OH_BASE_URL,
-            '/api/direct-sharing/project/remove-members/')
-        withdraw_url = urljoin(
-            withdraw_url,
-            '?access_token={}'.format(instance.get_access_token()))
-        requests.post(withdraw_url)
+        instance.deauth()


### PR DESCRIPTION
The OPENHUMANS_DEAUTH_ON_DELETE environment variable allows a user to be automatically deauthorized on local deletion.

This change adds in the ability to explicitly deauthorize a user outside of this through access to the OpenHumansMember class.

Fixes #24.